### PR TITLE
使用Vercel的边缘缓存

### DIFF
--- a/api/v1/index.js
+++ b/api/v1/index.js
@@ -30,6 +30,8 @@ export default function handler(req, res) {
         return;
     }
     console.log('url:', url);
+    //添加头
+    res.setHeader("Vercel-CDN-Cache-Control", "max-age=604800");
     if (cache[url]) {
         console.log('use cache');
         res.send(cache[url]);


### PR DESCRIPTION
在返回中添加 `Vercel-CDN-Cache-Control` 头以使用Vercel的边缘缓存，效果显著
![Snipaste_2024-02-13_10-05-18](https://github.com/xaoxuu/site-info-api/assets/63234268/7a67328d-bf3b-411e-a003-9fb6c10c856f)
